### PR TITLE
Added synchronous blocking API to Write time-series data into InfluxDB 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#34](https://github.com/bonitoo-io/influxdb-client-java/issues/34): Auto-configure client from configuration file
 1. [#35](https://github.com/bonitoo-io/influxdb-client-java/issues/35): Possibility to specify default tags
+1. [#41](https://github.com/bonitoo-io/influxdb-client-java/issues/41): Synchronous blocking API to Write time-series data into InfluxDB 2.0
 
 ### CI
 1. [#37](https://github.com/bonitoo-io/influxdb-client-java/issues/37): Switch CI from oraclejdk to openjdk 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ dependencies {
 package example;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.influxdata.annotations.Column;
@@ -139,6 +138,7 @@ import org.influxdata.client.InfluxDBClient;
 import org.influxdata.client.InfluxDBClientFactory;
 import org.influxdata.client.QueryApi;
 import org.influxdata.client.WriteApi;
+import org.influxdata.client.domain.WritePrecision;
 import org.influxdata.client.write.Point;
 import org.influxdata.query.FluxRecord;
 import org.influxdata.query.FluxTable;
@@ -162,14 +162,14 @@ public class InfluxDB2Example {
             Point point = Point.measurement("temperature")
                     .addTag("location", "west")
                     .addField("value", 55D)
-                    .time(Instant.now().toEpochMilli(), ChronoUnit.NANOS);
+                    .time(Instant.now().toEpochMilli(), WritePrecision.NS);
 
             writeApi.writePoint("bucket_name", "org_id", point);
 
             //
             // Write by LineProtocol
             //
-            writeApi.writeRecord("bucket_name", "org_id", ChronoUnit.NANOS, "temperature,location=north value=60.0");
+            writeApi.writeRecord("bucket_name", "org_id", WritePrecision.NS, "temperature,location=north value=60.0");
 
             //
             // Write by POJO
@@ -179,7 +179,7 @@ public class InfluxDB2Example {
             temperature.value = 62D;
             temperature.time = Instant.now();
 
-            writeApi.writeMeasurement("bucket_name", "org_id", ChronoUnit.NANOS, temperature);
+            writeApi.writeMeasurement("bucket_name", "org_id", WritePrecision.NS, temperature);
         }
 
         //

--- a/client-reactive/README.md
+++ b/client-reactive/README.md
@@ -192,11 +192,11 @@ The following example demonstrates how to write measurements every 10 seconds:
 package example;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdata.annotations.Column;
 import org.influxdata.annotations.Measurement;
+import org.influxdata.client.domain.WritePrecision;
 import org.influxdata.client.reactive.InfluxDBClientReactive;
 import org.influxdata.client.reactive.InfluxDBClientReactiveFactory;
 import org.influxdata.client.reactive.WriteReactiveApi;
@@ -226,7 +226,7 @@ public class WriteEvery10Seconds {
                     return temperature;
                 });
 
-        writeApi.writeMeasurements("bucket_name", "org_id", ChronoUnit.NANOS, measurements);
+        writeApi.writeMeasurements("bucket_name", "org_id", WritePrecision.NS, measurements);
 
         writeApi.close();
         influxDBClient.close();

--- a/client-reactive/src/main/java/org/influxdata/client/reactive/internal/WriteReactiveApiImpl.java
+++ b/client-reactive/src/main/java/org/influxdata/client/reactive/internal/WriteReactiveApiImpl.java
@@ -116,7 +116,8 @@ public class WriteReactiveApiImpl extends AbstractWriteClient implements WriteRe
         Arguments.checkNonEmpty(orgID, "organization");
         Arguments.checkNotNull(points, "points");
 
-        Flowable<BatchWriteDataPoint> stream = points.filter(Objects::nonNull).map(BatchWriteDataPoint::new);
+        Flowable<BatchWriteDataPoint> stream = points.filter(Objects::nonNull)
+                .map(point -> new BatchWriteDataPoint(point, options));
 
         write(bucket, orgID, stream);
     }
@@ -158,7 +159,8 @@ public class WriteReactiveApiImpl extends AbstractWriteClient implements WriteRe
         Arguments.checkNotNull(precision, "precision");
         Arguments.checkNotNull(measurements, "measurements");
 
-        Flowable<BatchWriteData> stream = measurements.map(it -> new BatchWriteDataMeasurement(it, precision));
+        Flowable<BatchWriteData> stream = measurements
+                .map(it -> new BatchWriteDataMeasurement(it, precision, options, measurementMapper));
 
         write(bucket, orgID, precision, stream);
     }

--- a/client/README.md
+++ b/client/README.md
@@ -21,6 +21,7 @@ The reference Java client that allows query, write and management (bucket, organ
     - authorizations
     - health check
 - [Advanced Usage](#advanced-usage)
+    - [Writing data using synchronous blocking API](#writing-data-using-synchronous-blocking-api)
     - [Client configuration file](#client-configuration-file)
     - [Client connection string](#client-connection-string)
     - [Gzip support](#gzip-support)
@@ -319,7 +320,7 @@ public class RawQueryAsynchronous {
 
 ## Writes
 
-For writing data we use [WriteApi](https://bonitoo-io.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApi.html) that supports:
+For writing data we use [WriteApi](https://bonitoo-io.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApi.html) that is an asynchronous non-blocking API and supports:
 
 1. writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point, POJO 
 2. use batching for writes
@@ -370,6 +371,8 @@ writeApi.listenEvents(BackpressureEvent.class, value -> {
 });
 ```
 
+There is also a synchronous blocking version of `WriteApi` - [WriteApiBlocking](#writing-data-using-synchronous-blocking-api).
+
 ### Writing data
 
 #### By POJO
@@ -380,13 +383,13 @@ Write Measurement into specified bucket:
 package example;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import org.influxdata.annotations.Column;
 import org.influxdata.annotations.Measurement;
 import org.influxdata.client.InfluxDBClient;
 import org.influxdata.client.InfluxDBClientFactory;
 import org.influxdata.client.WriteApi;
+import org.influxdata.client.domain.WritePrecision;
 
 public class WritePOJO {
 
@@ -409,7 +412,7 @@ public class WritePOJO {
             temperature.value = 62D;
             temperature.time = Instant.now();
 
-            writeApi.writeMeasurement("bucket_name", "org_id", ChronoUnit.NANOS, temperature);
+            writeApi.writeMeasurement("bucket_name", "org_id", WritePrecision.NS, temperature);
         }
 
         influxDBClient.close();
@@ -438,11 +441,11 @@ Write Data point into specified bucket:
 package example;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import org.influxdata.client.InfluxDBClient;
 import org.influxdata.client.InfluxDBClientFactory;
 import org.influxdata.client.WriteApi;
+import org.influxdata.client.domain.WritePrecision;
 import org.influxdata.client.write.Point;
 
 public class WriteDataPoint {
@@ -464,7 +467,7 @@ public class WriteDataPoint {
             Point point = Point.measurement("temperature")
                     .addTag("location", "west")
                     .addField("value", 55D)
-                    .time(Instant.now().toEpochMilli(), ChronoUnit.NANOS);
+                    .time(Instant.now().toEpochMilli(), WritePrecision.NS);
 
             writeApi.writePoint("bucket_name", "org_id", point);
         }
@@ -481,11 +484,10 @@ Write Line Protocol record into specified bucket:
 ```java
 package example;
 
-import java.time.temporal.ChronoUnit;
-
 import org.influxdata.client.InfluxDBClient;
 import org.influxdata.client.InfluxDBClientFactory;
 import org.influxdata.client.WriteApi;
+import org.influxdata.client.domain.WritePrecision;
 
 public class WriteLineProtocol {
 
@@ -505,7 +507,7 @@ public class WriteLineProtocol {
             //
             String record = "temperature,location=north value=60.0";
             
-            writeApi.writeRecord("bucket_name", "org_id", ChronoUnit.NANOS, record);
+            writeApi.writeRecord("bucket_name", "org_id", WritePrecision.NS, record);
         }
 
         influxDBClient.close();
@@ -666,6 +668,82 @@ public class InfluxDB2ManagementExample {
 ```
 
 ## Advanced Usage
+
+### Writing data using synchronous blocking API
+
+The [WriteApiBlocking](https://bonitoo-io.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApiBlocking.html) provides a synchronous blocking API to writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point and POJO. It's up to user to handle a server or a http exception.
+
+```java
+package example;
+
+import java.time.Instant;
+
+import org.influxdata.annotations.Column;
+import org.influxdata.annotations.Measurement;
+import org.influxdata.client.InfluxDBClient;
+import org.influxdata.client.InfluxDBClientFactory;
+import org.influxdata.client.WriteApiBlocking;
+import org.influxdata.client.domain.WritePrecision;
+import org.influxdata.client.write.Point;
+import org.influxdata.exceptions.InfluxException;
+
+public class WriteDataPoint {
+
+    private static char[] token = "my_token".toCharArray();
+
+    public static void main(final String[] args) throws Exception {
+
+
+        try (InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:9999", token)) {
+
+            WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+
+            //
+            // Write by LineProtocol
+            //
+            String record = "temperature,location=north value=60.0";
+
+            writeApi.writeRecord("bucket_name", "org_id", WritePrecision.NS, record);
+
+            //
+            // Write by Data Point
+            //
+            Point point = Point.measurement("temperature")
+                    .addTag("location", "west")
+                    .addField("value", 55D)
+                    .time(Instant.now().toEpochMilli(), WritePrecision.NS);
+
+            writeApi.writePoint("bucket_name", "org_id", point);
+
+            //
+            // Write by POJO
+            //
+            Temperature temperature = new Temperature();
+            temperature.location = "south";
+            temperature.value = 62D;
+            temperature.time = Instant.now();
+
+            writeApi.writeMeasurement("bucket_name", "org_id", WritePrecision.NS, temperature);
+            
+        } catch (InfluxException ie) {
+            System.out.println("InfluxException: " + ie);
+        }
+    }
+
+    @Measurement(name = "temperature")
+    private static class Temperature {
+
+        @Column(tag = true)
+        String location;
+
+        @Column
+        Double value;
+
+        @Column(timestamp = true)
+        Instant time;
+    }
+}
+```
 
 ### Client configuration file
 

--- a/client/README.md
+++ b/client/README.md
@@ -695,11 +695,11 @@ public class WriteDataPoint {
 
     public static void main(final String[] args) throws Exception {
 
+        InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:9999", token);
 
-        try (InfluxDBClient influxDBClient = InfluxDBClientFactory.create("http://localhost:9999", token)) {
-
-            WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
-
+        WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+        
+        try {
             //
             // Write by LineProtocol
             //
@@ -726,10 +726,12 @@ public class WriteDataPoint {
             temperature.time = Instant.now();
 
             writeApi.writeMeasurement("bucket_name", "org_id", WritePrecision.NS, temperature);
-            
+
         } catch (InfluxException ie) {
             System.out.println("InfluxException: " + ie);
         }
+
+        influxDBClient.close();
     }
 
     @Measurement(name = "temperature")

--- a/client/README.md
+++ b/client/README.md
@@ -671,7 +671,9 @@ public class InfluxDB2ManagementExample {
 
 ### Writing data using synchronous blocking API
 
-The [WriteApiBlocking](https://bonitoo-io.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApiBlocking.html) provides a synchronous blocking API to writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point and POJO. It's up to user to handle a server or a http exception.
+The [WriteApiBlocking](https://bonitoo-io.github.io/influxdb-client-java/influxdb-client-java/apidocs/org/influxdata/client/WriteApiBlocking.html) provides a synchronous blocking API to writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point and POJO. 
+
+_It's up to user to handle a server or a http exception._
 
 ```java
 package example;

--- a/client/src/main/java/org/influxdata/client/InfluxDBClient.java
+++ b/client/src/main/java/org/influxdata/client/InfluxDBClient.java
@@ -60,7 +60,7 @@ public interface InfluxDBClient extends AutoCloseable {
     QueryApi getQueryApi();
 
     /**
-     * Get the Write client.
+     * Get the asynchronous non-blocking Write client.
      *
      * @return the new client instance for the Write API
      */
@@ -68,7 +68,7 @@ public interface InfluxDBClient extends AutoCloseable {
     WriteApi getWriteApi();
 
     /**
-     * Get the Write client.
+     * Get the asynchronous non-blocking Write client.
      *
      * @param writeOptions the writes configuration
      * @return the new client instance for the Write API
@@ -76,6 +76,13 @@ public interface InfluxDBClient extends AutoCloseable {
     @Nonnull
     WriteApi getWriteApi(@Nonnull final WriteOptions writeOptions);
 
+    /**
+     * Get the synchronous blocking Write client.
+     *
+     * @return the new client instance for the Write API
+     */
+    @Nonnull
+    WriteApiBlocking getWriteApiBlocking();
 
     /**
      * Get the {@link Authorization} client.

--- a/client/src/main/java/org/influxdata/client/WriteApi.java
+++ b/client/src/main/java/org/influxdata/client/WriteApi.java
@@ -36,7 +36,7 @@ import org.influxdata.client.write.events.WriteRetriableErrorEvent;
 import org.influxdata.client.write.events.WriteSuccessEvent;
 
 /**
- * Write time-series data into InfluxDB 2.0.
+ * The asynchronous non-blocking API to Write time-series data into InfluxDB 2.0.
  * <p>
  * The data are formatted in <a href="https://bit.ly/2QL99fu">Line Protocol</a>.
  * <p>

--- a/client/src/main/java/org/influxdata/client/WriteApiBlocking.java
+++ b/client/src/main/java/org/influxdata/client/WriteApiBlocking.java
@@ -1,0 +1,286 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.influxdata.client;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.influxdata.client.domain.WritePrecision;
+import org.influxdata.client.write.Point;
+import org.influxdata.exceptions.InfluxException;
+
+/**
+ * The synchronous blocking API to Write time-series data into InfluxDB 2.0.
+ * <p>
+ * The data are formatted in <a href="https://bit.ly/2QL99fu">Line Protocol</a>.
+ * <p>
+ *
+ * @author Jakub Bednar (bednar@github) (20/09/2018 10:58)
+ */
+public interface WriteApiBlocking {
+
+    /**
+     * Write Line Protocol record into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeRecord(WritePrecision, String)}.
+     * </p>
+     *
+     * @param precision specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param record    specifies the record in InfluxDB Line Protocol.
+     *                  The {@code record} is considered as one batch unit.
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writeRecord(@Nonnull final WritePrecision precision,
+                     @Nullable final String record) throws InfluxException;
+
+    /**
+     * Write Line Protocol record into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeRecords(String, String, WritePrecision, List)}.
+     * </p>
+     *
+     * @param bucket    specifies the destination bucket for writes
+     * @param orgID     specifies the destination organization for writes
+     * @param precision specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param record    specifies the record in InfluxDB Line Protocol.
+     *                  The {@code record} is considered as one batch unit.
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writeRecord(@Nonnull final String bucket,
+                     @Nonnull final String orgID,
+                     @Nonnull final WritePrecision precision,
+                     @Nullable final String record) throws InfluxException;
+
+    /**
+     * Write Line Protocol records into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeRecords(WritePrecision, List)}.
+     * </p>
+     *
+     * @param precision specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param records   specifies the records in InfluxDB Line Protocol
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writeRecords(@Nonnull final WritePrecision precision,
+                      @Nonnull final List<String> records) throws InfluxException;
+
+    /**
+     * Write Line Protocol records into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeRecords(String, String, WritePrecision, List)}.
+     * </p>
+     *
+     * @param bucket    specifies the destination bucket for writes
+     * @param orgID     specifies the destination organization for writes
+     * @param precision specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param records   specifies the records in InfluxDB Line Protocol
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writeRecords(@Nonnull final String bucket,
+                      @Nonnull final String orgID,
+                      @Nonnull final WritePrecision precision,
+                      @Nonnull final List<String> records) throws InfluxException;
+
+    /**
+     * Write Data point into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writePoint(Point)}.
+     * </p>
+     *
+     * @param point specifies the Data point to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writePoint(@Nullable final Point point) throws InfluxException;
+
+    /**
+     * Write Data point into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writePoint(String, String, Point)}.
+     * </p>
+     *
+     * @param bucket specifies the destination bucket for writes
+     * @param orgID  specifies the destination organization for writes
+     * @param point  specifies the Data point to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writePoint(@Nonnull final String bucket,
+                    @Nonnull final String orgID,
+                    @Nullable final Point point) throws InfluxException;
+
+    /**
+     * Write Data points into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writePoints(List)}.
+     * </p>
+     *
+     * @param points specifies the Data points to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writePoints(@Nonnull final List<Point> points) throws InfluxException;
+
+
+    /**
+     * Write Data points into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writePoints(String, String, List)}.
+     * </p>
+     *
+     * @param bucket specifies the destination bucket ID for writes
+     * @param orgID  specifies the destination organization ID for writes
+     * @param points specifies the Data points to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    void writePoints(@Nonnull final String bucket,
+                     @Nonnull final String orgID,
+                     @Nonnull final List<Point> points) throws InfluxException;
+
+    /**
+     * Write Measurement into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeMeasurement(WritePrecision, Object)}.
+     * </p>
+     *
+     * @param precision   specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param <M>         measurement type
+     * @param measurement specifies the Measurement to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    <M> void writeMeasurement(@Nonnull final WritePrecision precision,
+                              @Nullable final M measurement) throws InfluxException;
+
+    /**
+     * Write Measurement into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeMeasurement(String, String, WritePrecision, Object)}.
+     * </p>
+     *
+     * @param bucket      specifies the destination bucket for writes
+     * @param orgID       specifies the destination organization for writes
+     * @param precision   specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param <M>         measurement type
+     * @param measurement specifies the Measurement to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    <M> void writeMeasurement(@Nonnull final String bucket,
+                              @Nonnull final String orgID,
+                              @Nonnull final WritePrecision precision,
+                              @Nullable final M measurement) throws InfluxException;
+
+    /**
+     * Write Measurements into specified bucket.
+     *
+     * <p>
+     * The {@link InfluxDBClientOptions#getBucket()} will be use as destination bucket
+     * and {@link InfluxDBClientOptions#getOrg()} will be used as destination organization.
+     * </p>
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeMeasurements(WritePrecision, List)}.
+     * </p>
+     *
+     * @param precision    specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param <M>          measurement type
+     * @param measurements specifies the Measurements to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    <M> void writeMeasurements(@Nonnull final WritePrecision precision,
+                               @Nonnull final List<M> measurements) throws InfluxException;
+
+    /**
+     * Write Measurements into specified bucket.
+     *
+     * <p>
+     * NOTE: This method directly write data info InfluxDB 2.0 without batching, jittering and backpressure.
+     * The method blocks the executing thread until their operation finished.
+     * There is also non-blocking alternative {@link WriteApi#writeMeasurements(String, String, WritePrecision, List)}.
+     * </p>
+     *
+     * @param bucket       specifies the destination bucket for writes
+     * @param orgID        specifies the destination organization for writes
+     * @param precision    specifies the precision for the unix timestamps within the body line-protocol (optional)
+     * @param <M>          measurement type
+     * @param measurements specifies the Measurements to write into bucket
+     * @throws InfluxException if a problem occurred during write time-series data into InfluxDB
+     */
+    <M> void writeMeasurements(@Nonnull final String bucket,
+                               @Nonnull final String orgID,
+                               @Nonnull final WritePrecision precision,
+                               @Nonnull final List<M> measurements) throws InfluxException;
+}

--- a/client/src/main/java/org/influxdata/client/internal/AbstractWriteClient.java
+++ b/client/src/main/java/org/influxdata/client/internal/AbstractWriteClient.java
@@ -72,7 +72,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient {
     private final PublishProcessor<Flowable<BatchWriteItem>> flushPublisher;
     private final PublishSubject<AbstractWriteEvent> eventPublisher;
 
-    private final MeasurementMapper measurementMapper = new MeasurementMapper();
+    protected final MeasurementMapper measurementMapper = new MeasurementMapper();
     private final WriteService service;
 
     public AbstractWriteClient(@Nonnull final WriteOptions writeOptions,
@@ -257,7 +257,7 @@ public abstract class AbstractWriteClient extends AbstractRestClient {
         String toLineProtocol();
     }
 
-    public final class BatchWriteDataRecord implements BatchWriteData {
+    public static final class BatchWriteDataRecord implements BatchWriteData {
 
         private final String record;
 
@@ -272,15 +272,16 @@ public abstract class AbstractWriteClient extends AbstractRestClient {
         }
     }
 
-    public final class BatchWriteDataPoint implements BatchWriteData {
+    public static final class BatchWriteDataPoint implements BatchWriteData {
 
         private final Point point;
+        private final InfluxDBClientOptions options;
 
-        public BatchWriteDataPoint(@Nonnull final Point point) {
-
-            Arguments.checkNotNull(point, "point");
+        public BatchWriteDataPoint(@Nonnull final Point point,
+                                   @Nonnull final InfluxDBClientOptions options) {
 
             this.point = point;
+            this.options = options;
         }
 
         @Nonnull
@@ -291,15 +292,21 @@ public abstract class AbstractWriteClient extends AbstractRestClient {
         }
     }
 
-    public final class BatchWriteDataMeasurement implements BatchWriteData {
+    public static final class BatchWriteDataMeasurement implements BatchWriteData {
 
         private final Object measurement;
         private final WritePrecision precision;
+        private final InfluxDBClientOptions options;
+        private final MeasurementMapper measurementMapper;
 
         public BatchWriteDataMeasurement(@Nullable final Object measurement,
-                                         @Nonnull final WritePrecision precision) {
+                                         @Nonnull final WritePrecision precision,
+                                         @Nonnull final InfluxDBClientOptions options,
+                                         @Nonnull final MeasurementMapper measurementMapper) {
             this.measurement = measurement;
             this.precision = precision;
+            this.options = options;
+            this.measurementMapper = measurementMapper;
         }
 
         @Nullable

--- a/client/src/main/java/org/influxdata/client/internal/InfluxDBClientImpl.java
+++ b/client/src/main/java/org/influxdata/client/internal/InfluxDBClientImpl.java
@@ -44,6 +44,7 @@ import org.influxdata.client.TemplatesApi;
 import org.influxdata.client.UsersApi;
 import org.influxdata.client.VariablesApi;
 import org.influxdata.client.WriteApi;
+import org.influxdata.client.WriteApiBlocking;
 import org.influxdata.client.WriteOptions;
 import org.influxdata.client.domain.Check;
 import org.influxdata.client.domain.IsOnboarding;
@@ -109,6 +110,12 @@ public final class InfluxDBClientImpl extends AbstractInfluxDBClient implements 
         Arguments.checkNotNull(writeOptions, "WriteOptions");
 
         return new WriteApiImpl(writeOptions, retrofit.create(WriteService.class), options);
+    }
+
+    @Nonnull
+    @Override
+    public WriteApiBlocking getWriteApiBlocking() {
+        return new WriteApiBlockingImpl(retrofit.create(WriteService.class), options);
     }
 
     @Nonnull

--- a/client/src/main/java/org/influxdata/client/internal/WriteApiBlockingImpl.java
+++ b/client/src/main/java/org/influxdata/client/internal/WriteApiBlockingImpl.java
@@ -24,33 +24,44 @@ package org.influxdata.client.internal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.influxdata.Arguments;
 import org.influxdata.client.InfluxDBClientOptions;
-import org.influxdata.client.WriteApi;
-import org.influxdata.client.WriteOptions;
+import org.influxdata.client.WriteApiBlocking;
 import org.influxdata.client.domain.WritePrecision;
+import org.influxdata.client.internal.AbstractWriteClient.BatchWriteData;
+import org.influxdata.client.internal.AbstractWriteClient.BatchWriteDataMeasurement;
+import org.influxdata.client.internal.AbstractWriteClient.BatchWriteDataPoint;
+import org.influxdata.client.internal.AbstractWriteClient.BatchWriteDataRecord;
 import org.influxdata.client.service.WriteService;
 import org.influxdata.client.write.Point;
-import org.influxdata.client.write.events.AbstractWriteEvent;
-import org.influxdata.client.write.events.EventListener;
-import org.influxdata.client.write.events.ListenerRegistration;
+import org.influxdata.internal.AbstractRestClient;
 
-import io.reactivex.Flowable;
-import io.reactivex.disposables.Disposable;
+import retrofit2.Call;
 
 /**
- * @author Jakub Bednar (bednar@github) (15/10/2018 09:42)
+ * @author Jakub Bednar (bednar@github) (16/07/2019 06:48)
  */
-final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
+final class WriteApiBlockingImpl extends AbstractRestClient implements WriteApiBlocking {
 
-    WriteApiImpl(@Nonnull final WriteOptions writeOptions,
-                 @Nonnull final WriteService service,
-                 @Nonnull final InfluxDBClientOptions options) {
+    private static final Logger LOG = Logger.getLogger(WriteApiBlockingImpl.class.getName());
 
-        super(writeOptions, options, writeOptions.getWriteScheduler(), service);
+    private final WriteService service;
+    private final InfluxDBClientOptions options;
+
+    private final MeasurementMapper measurementMapper = new MeasurementMapper();
+
+    WriteApiBlockingImpl(@Nonnull final WriteService service,
+                         @Nonnull final InfluxDBClientOptions options) {
+
+        this.service = service;
+        this.options = options;
     }
 
     @Override
@@ -68,19 +79,16 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
                             @Nonnull final WritePrecision precision,
                             @Nullable final String record) {
 
-        Arguments.checkNonEmpty(bucket, "bucket");
-        Arguments.checkNonEmpty(orgID, "orgID");
-        Arguments.checkNotNull(precision, "WritePrecision is required");
-
         if (record == null) {
             return;
         }
 
-        write(bucket, orgID, precision, Flowable.just(new BatchWriteDataRecord(record)));
+        write(bucket, orgID, precision, new BatchWriteDataRecord(record));
     }
 
     @Override
-    public void writeRecords(@Nonnull final WritePrecision precision, @Nonnull final List<String> records) {
+    public void writeRecords(@Nonnull final WritePrecision precision,
+                             @Nonnull final List<String> records) {
 
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
@@ -99,14 +107,11 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
         Arguments.checkNotNull(precision, "WritePrecision is required");
         Arguments.checkNotNull(records, "records");
 
-        Flowable<BatchWriteData> stream = Flowable.fromIterable(records).map(BatchWriteDataRecord::new);
-
-        write(bucket, orgID, precision, stream);
+        write(bucket, orgID, precision, records.stream().map(BatchWriteDataRecord::new));
     }
 
     @Override
     public void writePoint(@Nullable final Point point) {
-
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -114,10 +119,7 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
     }
 
     @Override
-    public void writePoint(@Nonnull final String bucket,
-                           @Nonnull final String orgID,
-                           @Nullable final Point point) {
-
+    public void writePoint(@Nonnull final String bucket, @Nonnull final String orgID, @Nullable final Point point) {
         if (point == null) {
             return;
         }
@@ -127,7 +129,6 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
 
     @Override
     public void writePoints(@Nonnull final List<Point> points) {
-
         Arguments.checkNotNull(options.getBucket(), "InfluxDBClientOptions.getBucket");
         Arguments.checkNotNull(options.getOrg(), "InfluxDBClientOptions.getOrg");
 
@@ -143,10 +144,10 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
         Arguments.checkNonEmpty(orgID, "orgID");
         Arguments.checkNotNull(points, "points");
 
-        Flowable<BatchWriteDataPoint> stream = Flowable.fromIterable(points).filter(Objects::nonNull)
-                .map(point -> new BatchWriteDataPoint(point, options));
-
-        write(bucket, orgID, stream);
+        points
+                .stream()
+                .filter(Objects::nonNull)
+                .forEach(point -> write(bucket, orgID, point.getPrecision(), new BatchWriteDataPoint(point, options)));
     }
 
     @Override
@@ -185,33 +186,42 @@ final class WriteApiImpl extends AbstractWriteClient implements WriteApi {
                                       @Nonnull final String orgID,
                                       @Nonnull final WritePrecision precision,
                                       @Nonnull final List<M> measurements) {
-
         Arguments.checkNonEmpty(bucket, "bucket");
         Arguments.checkNonEmpty(orgID, "orgID");
         Arguments.checkNotNull(precision, "WritePrecision is required");
         Arguments.checkNotNull(measurements, "records");
 
-        Flowable<BatchWriteData> stream = Flowable
-                .fromIterable(measurements)
-                .map(it -> new BatchWriteDataMeasurement(it, precision, options, measurementMapper));
-
-        write(bucket, orgID, precision, stream);
+        write(bucket, orgID, precision, measurements.stream()
+                .map(it -> new BatchWriteDataMeasurement(it, precision, options, measurementMapper)));
     }
 
-    @Nonnull
-    public <T extends AbstractWriteEvent> ListenerRegistration listenEvents(@Nonnull final Class<T> eventType,
-                                                                            @Nonnull final EventListener<T> listener) {
+    private void write(@Nonnull final String bucket,
+                       @Nonnull final String organization,
+                       @Nonnull final WritePrecision precision,
+                       @Nonnull final BatchWriteData data) {
 
-        Arguments.checkNotNull(eventType, "Type of listener");
-        Arguments.checkNotNull(listener, "Listener");
-
-        Disposable subscribe = super.addEventListener(eventType).subscribe(listener::onEvent);
-
-        return subscribe::dispose;
+        write(bucket, organization, precision, Stream.of(data));
     }
 
-    @Override
-    public void close() {
-        super.close();
+    private void write(@Nonnull final String bucket,
+                       @Nonnull final String organization,
+                       @Nonnull final WritePrecision precision,
+                       @Nonnull final Stream<BatchWriteData> stream) {
+
+        String lineProtocol = stream.map(BatchWriteData::toLineProtocol)
+                .filter(it -> it != null && !it.isEmpty())
+                .collect(Collectors.joining("\n"));
+
+        LOG.log(Level.FINEST,
+                "Writing time-series data into InfluxDB (org={0}, bucket={1}, precision={2})...",
+                new Object[]{organization, bucket, precision});
+
+        Call<Void> voidCall = service.postWrite(organization, bucket, lineProtocol, null,
+                "utf-8", "text/plain", null,
+                "application/json", precision);
+
+        execute(voidCall);
+
+        LOG.log(Level.FINEST, "Written data into InfluxDB: {0}", lineProtocol);
     }
 }

--- a/client/src/test/java/org/influxdata/client/H2OFeetMeasurement.java
+++ b/client/src/test/java/org/influxdata/client/H2OFeetMeasurement.java
@@ -49,9 +49,13 @@ public class H2OFeetMeasurement {
     }
 
     H2OFeetMeasurement(String location, Double level, String description, @Nullable final Long millis) {
+        this(location, level, description, millis != null ? Instant.ofEpochMilli(millis) : null);
+    }
+
+    H2OFeetMeasurement(String location, Double level, String description, @Nullable final Instant time) {
         this.location = location;
         this.level = level;
         this.description = description;
-        this.time = millis != null ? Instant.ofEpochMilli(millis) : null;
+        this.time = time;
     }
 }

--- a/client/src/test/java/org/influxdata/client/ITWriteApiBlocking.java
+++ b/client/src/test/java/org/influxdata/client/ITWriteApiBlocking.java
@@ -1,0 +1,197 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.influxdata.client;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import org.influxdata.client.domain.Authorization;
+import org.influxdata.client.domain.Bucket;
+import org.influxdata.client.domain.Organization;
+import org.influxdata.client.domain.Permission;
+import org.influxdata.client.domain.PermissionResource;
+import org.influxdata.client.domain.WritePrecision;
+import org.influxdata.client.write.Point;
+import org.influxdata.exceptions.BadRequestException;
+import org.influxdata.exceptions.InfluxException;
+import org.influxdata.query.FluxRecord;
+import org.influxdata.query.FluxTable;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jakub Bednar (bednar@github) (16/07/2019 07:13)
+ */
+@RunWith(JUnitPlatform.class)
+class ITWriteApiBlocking extends AbstractITClientTest {
+
+    private Bucket bucket;
+    private Organization organization;
+    private String token;
+
+    @BeforeEach
+    void setUp() throws Exception {
+
+        organization = findMyOrg();
+
+        bucket = influxDBClient.getBucketsApi()
+                .createBucket(generateName("h2o"), retentionRule(), organization);
+
+        PermissionResource resource = new PermissionResource();
+        resource.setId(bucket.getId());
+        resource.setOrgID(organization.getId());
+        resource.setType(PermissionResource.TypeEnum.BUCKETS);
+
+        //
+        // Add Permissions to read and write to the Bucket
+        //
+        Permission readBucket = new Permission();
+        readBucket.setResource(resource);
+        readBucket.setAction(Permission.ActionEnum.READ);
+
+        Permission writeBucket = new Permission();
+        writeBucket.setResource(resource);
+        writeBucket.setAction(Permission.ActionEnum.WRITE);
+
+        Authorization authorization = influxDBClient.getAuthorizationsApi()
+                .createAuthorization(organization, Arrays.asList(readBucket, writeBucket));
+
+        token = authorization.getToken();
+
+        influxDBClient.close();
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder()
+                .url(influxDB_URL)
+                .authenticateToken(token.toCharArray())
+                .org(organization.getId())
+                .bucket(bucket.getName())
+                .build();
+        influxDBClient = InfluxDBClientFactory.create(options);
+    }
+
+    @Test
+    void write() {
+
+        WriteApiBlocking api = influxDBClient.getWriteApiBlocking();
+
+        // By LineProtocol
+        api.writeRecord(WritePrecision.NS, "h2o,location=coyote_creek water_level=1.0 1");
+        api.writeRecord(bucket.getName(), organization.getName(), WritePrecision.NS, "h2o,location=coyote_creek water_level=2.0 2");
+        api.writeRecords(WritePrecision.NS, Arrays.asList("h2o,location=coyote_creek water_level=3.0 3", "h2o,location=coyote_creek water_level=4.0 4"));
+        api.writeRecords(bucket.getName(), organization.getName(), WritePrecision.NS, Arrays.asList("h2o,location=coyote_creek water_level=5.0 5", "h2o,location=coyote_creek water_level=6.0 6"));
+
+        // By DataPoint
+        api.writePoint(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 7.0D).time(7L, WritePrecision.NS));
+        api.writePoint(bucket.getName(), organization.getName(), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 8.0D).time(8L, WritePrecision.NS));
+        api.writePoints(Arrays.asList(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 9.0D).time(9L, WritePrecision.NS), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 10.0D).time(10L, WritePrecision.NS)));
+        api.writePoints(bucket.getName(), organization.getName(), Arrays.asList(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 11.0D).time(11L, WritePrecision.NS), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 12.0D).time(12L, WritePrecision.NS)));
+
+        // By Measurement
+        api.writeMeasurement(WritePrecision.NS, new H2OFeetMeasurement("coyote_creek", 13.0D, null, Instant.ofEpochSecond(0, 13)));
+        api.writeMeasurement(bucket.getName(), organization.getName(), WritePrecision.NS, new H2OFeetMeasurement("coyote_creek", 14.0D, null, Instant.ofEpochSecond(0, 14)));
+        api.writeMeasurements(WritePrecision.NS, Arrays.asList(new H2OFeetMeasurement("coyote_creek", 15.0D, null, Instant.ofEpochSecond(0, 15)), new H2OFeetMeasurement("coyote_creek", 16.0D, null, Instant.ofEpochSecond(0, 16))));
+        api.writeMeasurements(bucket.getName(), organization.getName(), WritePrecision.NS, Arrays.asList(new H2OFeetMeasurement("coyote_creek", 17.0D, null, Instant.ofEpochSecond(0, 17)), new H2OFeetMeasurement("coyote_creek", 18.0D, null, Instant.ofEpochSecond(0, 18))));
+
+        List<FluxTable> query = influxDBClient.getQueryApi().query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)", organization.getId());
+
+        Assertions.assertThat(query).hasSize(1);
+        Assertions.assertThat(query.get(0).getRecords()).hasSize(18);
+
+        for (int i = 1; i <= 17; i++) {
+            FluxRecord record = query.get(0).getRecords().get(i - 1);
+            Assertions.assertThat(record.getMeasurement()).isEqualTo("h2o");
+            Assertions.assertThat(record.getValue()).isEqualTo((double) i);
+            Assertions.assertThat(record.getField()).isEqualTo("water_level");
+            Assertions.assertThat(record.getTime()).isEqualTo(Instant.ofEpochSecond(0, i));
+        }
+    }
+
+    @Test
+    void propagateServerException() {
+
+        WriteApiBlocking api = influxDBClient.getWriteApiBlocking();
+
+        Assertions.assertThatThrownBy(() -> api.writeRecord(WritePrecision.NS, "h2o,location=coyote_creek"))
+                .hasMessageStartingWith("unable to parse points: unable to parse 'h2o,location=coyote_creek': missing fields")
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void propagateHttpException() throws Exception {
+
+        logout();
+
+        influxDBClient = InfluxDBClientFactory.create("http://localhost:9998", "my-token".toCharArray());
+        WriteApiBlocking api = influxDBClient.getWriteApiBlocking();
+
+        Assertions.assertThatThrownBy(() -> api.writeRecord(bucket.getName(), organization.getName(), WritePrecision.NS, "h2o,location=coyote_creek water_level=1.0 1"))
+                .hasMessageStartingWith("Failed to connect to")
+                .hasMessageEndingWith("9998")
+                .isInstanceOf(InfluxException.class);
+    }
+
+    @Test
+    void defaultTags() throws Exception {
+
+        influxDBClient.close();
+
+        System.setProperty("mine-sensor.version", "1.23a");
+        String envKey = (String) System.getenv().keySet().toArray()[5];
+
+        InfluxDBClientOptions options = InfluxDBClientOptions.builder().url(influxDB_URL)
+                .authenticateToken(token.toCharArray())
+                .addDefaultTag("id", "132-987-655")
+                .addDefaultTag("customer", "California Miner")
+                .addDefaultTag("env-var", "${env." + envKey + "}")
+                .addDefaultTag("sensor-version", "${mine-sensor.version}")
+                .build();
+
+        influxDBClient = InfluxDBClientFactory.create(options);
+
+        Instant time = Instant.now();
+
+        Point point = Point
+                .measurement("h2o")
+                .addTag("location", "west")
+                .addField("water_level", 1)
+                .time(time, WritePrecision.MS);
+
+        influxDBClient.getWriteApiBlocking().writePoint(bucket.getName(), organization.getId(), point);
+
+        List<FluxTable> query = influxDBClient.getQueryApi().query("from(bucket:\"" + bucket.getName() + "\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")", organization.getId());
+
+        Assertions.assertThat(query).hasSize(1);
+        Assertions.assertThat(query.get(0).getRecords()).hasSize(1);
+        Assertions.assertThat(query.get(0).getRecords().get(0).getMeasurement()).isEqualTo("h2o");
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("water_level")).isEqualTo(1L);
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("location")).isEqualTo("west");
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("id")).isEqualTo("132-987-655");
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("customer")).isEqualTo("California Miner");
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("sensor-version")).isEqualTo("1.23a");
+        Assertions.assertThat(query.get(0).getRecords().get(0).getValueByKey("env-var")).isEqualTo(System.getenv(envKey));
+    }
+}

--- a/client/src/test/java/org/influxdata/client/ITWriteApiBlocking.java
+++ b/client/src/test/java/org/influxdata/client/ITWriteApiBlocking.java
@@ -101,18 +101,21 @@ class ITWriteApiBlocking extends AbstractITClientTest {
         // By LineProtocol
         api.writeRecord(WritePrecision.NS, "h2o,location=coyote_creek water_level=1.0 1");
         api.writeRecord(bucket.getName(), organization.getName(), WritePrecision.NS, "h2o,location=coyote_creek water_level=2.0 2");
+        api.writeRecord(bucket.getName(), organization.getName(), WritePrecision.NS, null);
         api.writeRecords(WritePrecision.NS, Arrays.asList("h2o,location=coyote_creek water_level=3.0 3", "h2o,location=coyote_creek water_level=4.0 4"));
         api.writeRecords(bucket.getName(), organization.getName(), WritePrecision.NS, Arrays.asList("h2o,location=coyote_creek water_level=5.0 5", "h2o,location=coyote_creek water_level=6.0 6"));
 
         // By DataPoint
         api.writePoint(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 7.0D).time(7L, WritePrecision.NS));
         api.writePoint(bucket.getName(), organization.getName(), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 8.0D).time(8L, WritePrecision.NS));
+        api.writePoint(bucket.getName(), organization.getName(), null);
         api.writePoints(Arrays.asList(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 9.0D).time(9L, WritePrecision.NS), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 10.0D).time(10L, WritePrecision.NS)));
         api.writePoints(bucket.getName(), organization.getName(), Arrays.asList(Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 11.0D).time(11L, WritePrecision.NS), Point.measurement("h2o").addTag("location", "coyote_creek").addField("water_level", 12.0D).time(12L, WritePrecision.NS)));
 
         // By Measurement
         api.writeMeasurement(WritePrecision.NS, new H2OFeetMeasurement("coyote_creek", 13.0D, null, Instant.ofEpochSecond(0, 13)));
         api.writeMeasurement(bucket.getName(), organization.getName(), WritePrecision.NS, new H2OFeetMeasurement("coyote_creek", 14.0D, null, Instant.ofEpochSecond(0, 14)));
+        api.writeMeasurement(bucket.getName(), organization.getName(), WritePrecision.NS, null);
         api.writeMeasurements(WritePrecision.NS, Arrays.asList(new H2OFeetMeasurement("coyote_creek", 15.0D, null, Instant.ofEpochSecond(0, 15)), new H2OFeetMeasurement("coyote_creek", 16.0D, null, Instant.ofEpochSecond(0, 16))));
         api.writeMeasurements(bucket.getName(), organization.getName(), WritePrecision.NS, Arrays.asList(new H2OFeetMeasurement("coyote_creek", 17.0D, null, Instant.ofEpochSecond(0, 17)), new H2OFeetMeasurement("coyote_creek", 18.0D, null, Instant.ofEpochSecond(0, 18))));
 

--- a/client/src/test/java/org/influxdata/client/InfluxDBClientTest.java
+++ b/client/src/test/java/org/influxdata/client/InfluxDBClientTest.java
@@ -82,6 +82,11 @@ class InfluxDBClientTest extends AbstractInfluxDBClientTest {
     }
 
     @Test
+    void createWriteBlockingApi() {
+        Assertions.assertThat(influxDBClient.getWriteApiBlocking()).isNotNull();
+    }
+    
+    @Test
     void logLevel() {
 
         // default NONE


### PR DESCRIPTION
Closes #41 #7 

Added synchronous blocking API to Write time-series data into InfluxDB 2.0

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)